### PR TITLE
Remove the unused and deprecated rbnacl-libsodium dependency

### DIFF
--- a/lib/sirp.rb
+++ b/lib/sirp.rb
@@ -1,6 +1,5 @@
 require 'openssl'
 require 'digest'
-require 'rbnacl/libsodium'
 require 'sysrandom/securerandom'
 require 'hashie'
 require 'sirp/sirp'

--- a/sirp.gemspec
+++ b/sirp.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # See : https://bugs.ruby-lang.org/issues/9569
-  spec.add_runtime_dependency 'rbnacl-libsodium', '~> 1.0'
   spec.add_runtime_dependency 'sysrandom', '~> 1.0'
   spec.add_runtime_dependency 'hashie', '~> 3.4'
 


### PR DESCRIPTION
Hi,

`rbnacl-libsodium` has been deprecated (https://github.com/crypto-rb/rbnacl-libsodium/issues/29#issuecomment-437146040) and `rbnacl 6.0.0` raises the following error in presence of it:

```
Bundler::GemRequireError: There was an error while trying to load the gem 'sirp'.
Gem Load Error is: rbnacl-libsodium is not supported by rbnacl 6.0+. Please remove it as a dependency and install libsodium using your system package manager. See https://github.com/crypto-rb/rbnacl#installation
```

It was added as a dependency of `securer_randomer` by this commit: https://github.com/grempe/sirp/commit/f836bbe294536ad4c8f8ecb316a4810b0d8c1f74

However, as of https://github.com/grempe/sirp/commit/3b65ceafb7c0a3176515732a73466994243dd02a, `securer_randomer` has been replaced with `sysrandom` which doesn't need `rbnacl-libsodium`.